### PR TITLE
feat: new defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,8 +2,10 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = tab
+indent_style = space
 indent_size = 2
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 100
+quote_type = single

--- a/README.md
+++ b/README.md
@@ -1,23 +1,30 @@
-### 📝🔧 Editorconfig CLI
+# 📝🔧 Editorconfig CLI
+
 Initialize .editorconfig in your terminal
 
 ---
-#### Installation
+
+## Installation
+
 ```sh
 npm i -g editorconfig-cli
 ```
 
-#### Commands
-* `init` - create new .editorconfig
-* `add-rules` - add rules to existing .editorconfig file
+## Commands
 
-#### Usage
+- `init` - create new .editorconfig
+- `add-rules` - add rules to existing .editorconfig file
+
+## Usage
+
 ```sh
 ec init
 ```
+
 ![usage](http://i.imgur.com/Swvr12G.gif)
 
 to use defaults w/o questionnaire:
+
 ```sh
 ec init -y
 ```
@@ -25,9 +32,18 @@ ec init -y
 ```sh
 ec add-rules
 ```
+
+## Generate a new .editorconfig without any installs
+
+```sh
+npx editorconfig-cli init -y
+```
+
+
 ![usage](http://i.imgur.com/tRss4Gd.gif)
 
 #### Help
+
 ```sh
 ec --help
 ```

--- a/bin/ec
+++ b/bin/ec
@@ -4,19 +4,17 @@ var program = require('commander');
 var version = require('../package.json').version;
 var actions = require('../lib/actions');
 
-program
-	.version(version);
+program.version(version);
 
 program
-	.command('init')
-	.description('create new .editorconfig')
-	.option('-y, --yes', 'skip questionnaire')
-	.action(actions.init);
+  .command('init')
+  .description('create new .editorconfig')
+  .option('-y, --yes', 'skip questionnaire')
+  .action(actions.init);
 
 program
-	.command('add-rules')
-	.description('add rules to existing .editorconfig file')
-	.action(actions.addRules)
+  .command('add-rules')
+  .description('add rules to existing .editorconfig file')
+  .action(actions.addRules);
 
-program
-	.parse(process.argv);
+program.parse(process.argv);

--- a/lib/ECFile.js
+++ b/lib/ECFile.js
@@ -1,66 +1,70 @@
-var fs       = require('fs');
-var path     = require('path');
+var fs = require('fs');
+var path = require('path');
 var ecparser = require('editorconfig/lib/ini');
 
 module.exports = ECFile;
 
 function ECFile(config) {
-	this.root = config.root || false;
-	this.sections = config.sections || [];
+  this.root = config.root || false;
+  this.sections = config.sections || [];
 }
 
 ECFile.readSync = function (folder) {
-	var sections = ecparser.parseSync(path.join(folder, '.editorconfig'));
-	var config = {
-		root: false,
-		sections: []
-	};
+  var sections = ecparser.parseSync(path.join(folder, '.editorconfig'));
+  var config = {
+    root: false,
+    sections: [],
+  };
 
-	sections.forEach(function (section) {
-		var sectionName = section[0];
-		var rules = section[1];
+  sections.forEach(function (section) {
+    var sectionName = section[0];
+    var rules = section[1];
 
-		if (!sectionName) {
-			if (rules.root) {
-				config.root = true;
-			}
-			return;
-		}
+    if (!sectionName) {
+      if (rules.root) {
+        config.root = true;
+      }
+      return;
+    }
 
-		config.sections.push(new Section(sectionName, rules));
-	});
+    config.sections.push(new Section(sectionName, rules));
+  });
 
-	return new ECFile(config);
+  return new ECFile(config);
 };
 
 ECFile.prototype.writeSync = function (folder) {
-	fs.writeFileSync(path.join(folder, '.editorconfig'), this.toString());
+  fs.writeFileSync(path.join(folder, '.editorconfig'), this.toString());
 };
 
 ECFile.prototype.addSection = function (sectionName, rules) {
-	this.sections.push(new Section(sectionName, rules));
+  this.sections.push(new Section(sectionName, rules));
 };
 
 ECFile.prototype.toString = function () {
-	return (this.root ? 'root = true\n\n' : '') +
-		this.sections.map(function (section) {
-			return section.toString();
-		})
-		.join('\n\n') + '\n';
+  return (
+    (this.root ? 'root = true\n\n' : '') +
+    this.sections
+      .map(function (section) {
+        return section.toString();
+      })
+      .join('\n\n') +
+    '\n'
+  );
 };
 
 function Section(name, rules) {
-	this.name = name;
-	this.rules = rules;
+  this.name = name;
+  this.rules = rules;
 }
 
 Section.prototype.toString = function () {
-	var heading = '[' + this.name + ']\n';
-	var body = [];
+  var heading = '[' + this.name + ']\n';
+  var body = [];
 
-	for (var key in this.rules) {
-		body.push(key + ' = ' + this.rules[key]);
-	}
+  for (var key in this.rules) {
+    body.push(key + ' = ' + this.rules[key]);
+  }
 
-	return heading + body.join('\n');
+  return heading + body.join('\n');
 };

--- a/lib/Rule.js
+++ b/lib/Rule.js
@@ -1,39 +1,39 @@
 module.exports = Rule;
 
 function Rule(config) {
-	this.name = config.name;
-	this.type = config.type;
-	this.defaultValue = config.defaultValue || null;
+  this.name = config.name;
+  this.type = config.type;
+  this.defaultValue = config.defaultValue || null;
 
-	if (this.type === 'enum') {
-		this.values = config.values;
-		this.defaultValue = config.values[0];
-	}
+  if (this.type === 'enum') {
+    this.values = config.values;
+    this.defaultValue = config.values[0];
+  }
 }
 
 Rule.prototype.getReadableName = function () {
-	return this.name.split('_').join(' ');
+  return this.name.split('_').join(' ');
 };
 
 Rule.prototype.toQuestion = function () {
-	var q = {};
+  var q = {};
 
-	q.name = this.name;
-	q.message = this.getReadableName() + '?';
+  q.name = this.name;
+  q.message = this.getReadableName() + '?';
 
-	switch(this.type) {
-		case 'enum':
-			q.type = 'list';
-			q.choices = this.values;
-			break;
-		case 'bool':
-			q.type = 'confirm';
-			break;
-		default:
-			q.type = 'input';
-	}
+  switch (this.type) {
+    case 'enum':
+      q.type = 'list';
+      q.choices = this.values;
+      break;
+    case 'bool':
+      q.type = 'confirm';
+      break;
+    default:
+      q.type = 'input';
+  }
 
-	q.default = this.defaultValue;
+  q.default = this.defaultValue;
 
-	return q;
+  return q;
 };

--- a/lib/actions/add-rules.js
+++ b/lib/actions/add-rules.js
@@ -1,48 +1,51 @@
 var inquirer = require('inquirer');
-var rules    = require('../rules');
-var ECFile   = require('../ECFile');
+var rules = require('../rules');
+var ECFile = require('../ECFile');
 
 var cwd = process.cwd();
 
-var questions = [{
-	name: 'sectionName',
-	message: 'File path pattern? (e.g lib/*.{js})',
-	validate: function (answer) {
-		return answer.trim().length > 0;
-	}
-}, {
-	name: 'rules',
-	message: 'What rules do you want to add to this section?',
-	type: 'checkbox',
-	choices: rules.map(function (rule) {
-		return {
-			name: rule.getReadableName(),
-			value: rule,
-			checked: true
-		};
-	}),
-	validate: function (answer) {
-		if (answer.length > 0) {
-			return true;
-		}
+var questions = [
+  {
+    name: 'sectionName',
+    message: 'File path pattern? (e.g lib/*.{js})',
+    validate: function (answer) {
+      return answer.trim().length > 0;
+    },
+  },
+  {
+    name: 'rules',
+    message: 'What rules do you want to add to this section?',
+    type: 'checkbox',
+    choices: rules.map(function (rule) {
+      return {
+        name: rule.getReadableName(),
+        value: rule,
+        checked: true,
+      };
+    }),
+    validate: function (answer) {
+      if (answer.length > 0) {
+        return true;
+      }
 
-		return 'Select at least one rule';
-	}
-}];
+      return 'Select at least one rule';
+    },
+  },
+];
 
 module.exports = function () {
-	var ecfile = ECFile.readSync(cwd);
-	
-	inquirer.prompt(questions, function (answers) {
-		var sectionName = answers.sectionName;
+  var ecfile = ECFile.readSync(cwd);
 
-		var questions = answers.rules.map(function (rule) {
-			return rule.toQuestion();
-		});
+  inquirer.prompt(questions, function (answers) {
+    var sectionName = answers.sectionName;
 
-		inquirer.prompt(questions, function (answers) {
-			ecfile.addSection(sectionName, answers);
-			ecfile.writeSync(cwd);
-		});
-	});
+    var questions = answers.rules.map(function (rule) {
+      return rule.toQuestion();
+    });
+
+    inquirer.prompt(questions, function (answers) {
+      ecfile.addSection(sectionName, answers);
+      ecfile.writeSync(cwd);
+    });
+  });
 };

--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -2,6 +2,6 @@ var init = require('./init.js');
 var addRules = require('./add-rules.js');
 
 module.exports = {
-	init: init,
-	addRules: addRules
+  init: init,
+  addRules: addRules,
 };

--- a/lib/actions/init.js
+++ b/lib/actions/init.js
@@ -1,53 +1,58 @@
-var fs       = require('fs');
-var path     = require('path');
+var fs = require('fs');
+var path = require('path');
 var inquirer = require('inquirer');
-var rules    = require('../rules');
-var ECFile   = require('../ECFile');
+var rules = require('../rules');
+var ECFile = require('../ECFile');
 
 var cwd = process.cwd();
 
 var questions = rules.map(function (rule) {
-	return rule.toQuestion();
+  return rule.toQuestion();
 });
 
 function writeDefaults() {
-	var ecfile = new ECFile({ root: true });
-	var defaults = rules.reduce(function (defaults, rule) {
-		defaults[rule.name] = rule.defaultValue;
-		return defaults;
-	}, {});
+  var ecfile = new ECFile({ root: true });
+  var defaults = rules.reduce(function (defaults, rule) {
+    defaults[rule.name] = rule.defaultValue;
+    return defaults;
+  }, {});
 
-	ecfile.addSection('*', defaults);
-	ecfile.writeSync(cwd);
+  ecfile.addSection('*', defaults);
+  ecfile.writeSync(cwd);
 
-	console.log(ecfile.toString());
+  console.log(ecfile.toString());
 }
 
 function done(answers) {
-	var ecfile = new ECFile({ root: true });
-	ecfile.addSection('*', answers);
+  var ecfile = new ECFile({ root: true });
+  ecfile.addSection('*', answers);
 
-	process.stdout.write('\n' + ecfile.toString() + '\n');
+  process.stdout.write('\n' + ecfile.toString() + '\n');
 
-	inquirer.prompt([{
-		name: 'ok',
-		message: 'Ok?',
-		default: true,
-		type: 'confirm'
-	}], function (answer) {
-		if (answer.ok) {
-			ecfile.writeSync(cwd);
-		} else {
-			process.stdout.write('\n');
-			inquirer.prompt(questions, done);
-		}
-	});
+  inquirer.prompt(
+    [
+      {
+        name: 'ok',
+        message: 'Ok?',
+        default: true,
+        type: 'confirm',
+      },
+    ],
+    function (answer) {
+      if (answer.ok) {
+        ecfile.writeSync(cwd);
+      } else {
+        process.stdout.write('\n');
+        inquirer.prompt(questions, done);
+      }
+    }
+  );
 }
 
 module.exports = function (cmd) {
-	if (cmd.yes) {
-		return writeDefaults();
-	}
+  if (cmd.yes) {
+    return writeDefaults();
+  }
 
-	inquirer.prompt(questions, done);
+  inquirer.prompt(questions, done);
 };

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -1,29 +1,52 @@
 var Rule = require('./Rule');
 
-module.exports = [{
-	name: 'charset',
-	type: 'enum',
-	values: ['utf-8', 'latin1', 'utf-16le', 'utf-16be']
-}, {
-	name: 'indent_style',
-	type: 'enum',
-	values: ['tab', 'space']
-}, {
-	name: 'indent_size',
-	type: 'number',
-	defaultValue: 2
-}, {
-	name: 'end_of_line',
-	type: 'enum',
-	values: ['lf', 'crlf', 'cr']
-}, {
-	name: 'trim_trailing_whitespace',
-	type: 'bool',
-	defaultValue: true
-}, {
-	name: 'insert_final_newline',
-	type: 'bool',
-	defaultValue: true
-}].map(function (ruleConfig) {
-	return new Rule(ruleConfig);
+module.exports = [
+  {
+    name: 'charset',
+    type: 'enum',
+    values: ['utf-8', 'latin1', 'utf-16le', 'utf-16be'],
+    defaultValue: 'utf-8',
+  },
+  {
+    name: 'indent_style',
+    type: 'enum',
+    values: ['space', 'tab'],
+    defaultValue: 'space',
+  },
+  {
+    name: 'indent_size',
+    type: 'number',
+    defaultValue: 2,
+  },
+  {
+    name: 'end_of_line',
+    type: 'enum',
+    values: ['lf', 'crlf', 'cr'],
+    defaultValue: 'lf',
+  },
+  {
+    name: 'trim_trailing_whitespace',
+    type: 'bool',
+    defaultValue: true,
+  },
+  {
+    name: 'insert_final_newline',
+    type: 'bool',
+    defaultValue: true,
+  },
+  {
+    // https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length
+    name: 'max_line_length',
+    type: 'number',
+    defaultValue: 100,
+  },
+  {
+    // https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length:~:text=Domain-,quote_type,-single%2C%20double
+    name: 'quote_type',
+    type: 'enum',
+    values: ['single', 'double', 'auto'],
+    defaultValue: 'auto',
+  },
+].map(function (ruleConfig) {
+  return new Rule(ruleConfig);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,449 @@
+{
+  "name": "editorconfig-cli",
+  "version": "0.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "editorconfig-cli",
+      "version": "0.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.8.1",
+        "editorconfig": "^0.13.0",
+        "inquirer": "^1.2.3"
+      },
+      "bin": {
+        "ec": "bin/ec"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
+      "dependencies": {
+        "restore-cursor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+    },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/editorconfig": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
+      "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
+      "dependencies": {
+        "bluebird": "^3.0.5",
+        "commander": "^2.9.0",
+        "lru-cache": "^3.2.0",
+        "semver": "^5.1.0",
+        "sigmund": "^1.0.1"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/external-editor": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "integrity": "sha512-0XYlP43jzxMgJjugDJ85Z0UDPnowkUbfFztNvsSGC9sJVIk97MZbGEb9WAhIVH0UgNxoLj/9ZQgB4CHJyz2GGQ==",
+      "dependencies": {
+        "extend": "^3.0.0",
+        "spawn-sync": "^1.0.15",
+        "tmp": "^0.0.29"
+      }
+    },
+    "node_modules/figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/inquirer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+      "integrity": "sha512-diSnpgfv/Ozq6QKuV2mUcwZ+D24b03J3W6EVxzvtkCWJTPrH2gKLsqgSW0vzRMZZFhFdhnvzka0RUJxIm7AOxQ==",
+      "dependencies": {
+        "ansi-escapes": "^1.1.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "external-editor": "^1.1.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.6",
+        "pinkie-promise": "^2.0.0",
+        "run-async": "^2.2.0",
+        "rx": "^4.1.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lru-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+      "integrity": "sha512-91gyOKTc2k66UG6kHiH4h3S2eltcPwE1STVfMYC/NG+nZwf8IIuiamfmpGZjpbbxzSyEJaLC0tNSmhjlQUTJow==",
+      "dependencies": {
+        "pseudomap": "^1.0.1"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+      "integrity": "sha512-m0kBTDLF/0lgzCsPVmJSKM5xkLNX7ZAB0Q+n2DP37JMIRPVC2R4c3BdO6x++bXFKftbhvSfKgwxAexME+BRDRw=="
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
+      "dependencies": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug=="
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g=="
+    },
+    "node_modules/spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/tmp": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+      "integrity": "sha512-89PTqMWGDva+GqClOqBV9s3SMh7MA3Mq0pJUdAoHuF65YoE7O0LermaZkVfT5/Ngfo18H4eYiyG7zKOtnEbxsw==",
+      "dependencies": {
+        "os-tmpdir": "~1.0.1"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
   "dependencies": {
     "commander": "^2.8.1",
     "editorconfig": "^0.13.0",
-    "inquirer": "^0.10.1"
+    "inquirer": "^1.2.3"
+  },
+  "scripts": {
+    "test:init": "node bin/ec init",
+    "test:init:y": "node bin/ec init -y",
+    "test:add-rules": "node bin/ec add-rules"
   }
 }


### PR DESCRIPTION
# In this change:
- fixed 2 critical vulnerabilities (see below) by only bumping inquirer tot 1.2.3
- added defaultValue for `indent_style` to be `space` (more commonly acceptated)
- added new `max_line_length` (generally supported) and `quote_type` (somewhat supported)
- formatted js files using prettier default settings
- updated the README.md file to describe `npx` usage
- added scripts to be able to consistantly test
- added `package-lock.json` to git as it should be there

## Questions
- unsure what `ec add-rules` should do, it fails
- tested on Node 20, should it have a `.nvmrc`?

## Fixed vulnerabilities:

```sh
❯ npm audit
# npm audit report

lodash  <=4.17.20
Severity: critical
Regular Expression Denial of Service (ReDoS) in lodash - https://github.com/advisories/GHSA-x5rq-j2xg-h7qm
Prototype Pollution in lodash - https://github.com/advisories/GHSA-fvqr-27wr-82fm
Prototype Pollution in lodash - https://github.com/advisories/GHSA-jf85-cpcp-j695
Prototype Pollution in lodash - https://github.com/advisories/GHSA-4xc9-xhrj-v574
Regular Expression Denial of Service (ReDoS) in lodash - https://github.com/advisories/GHSA-29mw-wpgm-hmr9
Prototype Pollution in lodash - https://github.com/advisories/GHSA-p6mc-m468-83gw
Command Injection in lodash - https://github.com/advisories/GHSA-35jh-r3h4-6jhm
fix available via `npm audit fix --force`
Will install inquirer@9.2.19, which is a breaking change
node_modules/lodash
  inquirer  <=0.11.4
  Depends on vulnerable versions of lodash
  node_modules/inquirer

2 critical severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force
```

Closes #3 